### PR TITLE
Quickfix para el ícono de verificado

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
     var dataSource = 'osl.json';
-    var source   = "{{#each sites}}<tr><td>{{title}}</td><td><a href='{{URL}}'>{{URL}}</a></td><td>{{description}}</td><td class='center'><i title='Verificado' class='support-level-{{support-level}}'></i></td></tr>{{/each}}";
+    var source   = "{{#each sites}}<tr><td>{{title}}</td><td><a href='{{URL}}'>{{URL}}</a></td><td>{{description}}</td><td class='center'><i title='Verificado' class='support-level-{{#if verified}}full{{else}}none{{/if}}'></i></td></tr>{{/each}}";
 	var template = Handlebars.compile(source);
     $.getJSON(dataSource, function (data) {
 		var html    = template(data);


### PR DESCRIPTION
Por si querés aplicar un quickfix mientras hacen algo más elaborado (como mostrar la columna de support + verified), este es el quickfix para que el ícono salga rojo si no esta verificado.
